### PR TITLE
Update openvpn-site.ovpn to use lport

### DIFF
--- a/openvpn-site.ovpn
+++ b/openvpn-site.ovpn
@@ -4,7 +4,7 @@ port 1194
 proto udp
 resolv-retry infinite
 mode p2p
-nobind
+lport 1194
 persist-tun
 verb 3
 keepalive 10 120

--- a/openvpn-site.ovpn
+++ b/openvpn-site.ovpn
@@ -5,6 +5,8 @@ proto udp
 resolv-retry infinite
 mode p2p
 lport 1194
+data-ciphers BF-CBC
+providers legacy default
 persist-tun
 verb 3
 keepalive 10 120


### PR DESCRIPTION
Hi. I'm using the UDM Pro and the config.gateway.json approch no longer works. So after browser the documentaion, I discovered that using `lport` you can actually make it compatible with the Unifi approch. Also, the new openVPN doen't like the Unifi's ciper, so compatible settings are also required.